### PR TITLE
Filter chapter URLs to remove TL group URLs

### DIFF
--- a/src/dl/page/chapterIterator.ts
+++ b/src/dl/page/chapterIterator.ts
@@ -44,7 +44,7 @@ const getURLsFromTable = async (
     return await chapterTable!!.$$eval("a", option => {
         return option.map(link => {
             return link.getAttribute("href");
-        }).filter(x => x !== null);
+        }).filter(x => x !== null).filter(x => x.startsWith("/comic/"));
     });
 }
 


### PR DESCRIPTION
### Problem
Currently, when reading URLs from the chapter table, the program can pick up group URLs in addition to comic URLs. Attempting to process these links causes the program to crash, as seen below:

Command:
```shell
bun run index.ts --series "senpai-kanojo" --language "en" --group "RanumataTL" --outputPath "C:\Users\username\Documents\comick\Senpai Kanojo"
``` 
Output:
```
Series URL: https://comick.io/comic/senpai-kanojo?date-order=&chap-order=1&lang=en&group=RanumataTL
1
14
Current URL: https://comick.io/comic/senpai-kanojo/bJYcdTFq-chapter-1-en
Current URL: https://comick.io/group/ranumata-tl
 8 |     const readerElement = (await page.$(readerSectionID));
 9 |     if (readerElement !== null) {
10 |         return readerElement;
11 |     }
12 |
13 |     throw new Error(`Element with id ${readerSectionID} could not be found`);
               ^
error: Element with id #images-reader-container could not be found
      at <anonymous> (C:\Users\username\repos\comick-downloader\src\dl\page\chapterDownload.ts:13:11)

Bun v1.2.17 (Windows x64)
``` 
### Proposed Solution
To fix this, I added an additional filter to ensure only comic URLs are extracted from the table.